### PR TITLE
toolchain-sources-builder.sh: bump nextpnr-xilinx to latest commit

### DIFF
--- a/toolchain-sources-builder.sh
+++ b/toolchain-sources-builder.sh
@@ -19,9 +19,10 @@ DEPENDENCIES="$DEPENDENCIES python3-pytest-runner python3-scipy python3-simplejs
 # Tools commit hash.
 # Yosys
 YOSYS_HASH=yosys-0.62
-# nextpnr xilinx (stable-backports 2025-03-10)
-NEXTPNR_XILINX_HASH=3374e5a62b54dc346fd5f85188ed24075ddfd5fb
-NEXTPNR_XILINX_HASH=0.8.2
+
+# (stable_backports 20260323)
+NEXTPNR_XILINX_HASH=f681eb3aa519f6ed41670dd8a4b39f87e9fb5498
+
 # prjxray (master 2025-02-19)
 PRJXRAY_HASH=ce065d470ea9547bba97b9df4476a0148e728c95
 # prjxray-db (master 2025-02-19)


### PR DESCRIPTION
nextpnr-xilinx repository has been updated to fix build with recent OS.
This PR bump the hash to the latest commit.